### PR TITLE
Make builds work on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - "2.2.0"
   - "2.3.0"
   - "2.4.0"
   - "2.5.0"
@@ -8,5 +7,7 @@ rvm:
   - "2.7.0"
   - "3.0.0"
 before_install:
+ - yes | gem update --system --force
+ - gem install bundler
  - sudo apt-get install -qq libjpeg-progs optipng
 script: bundle exec rspec -b spec

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ which supports many external optimization libraries such as [advpng](http://adva
 
 ### What's new
 
-**2020-03-27 3.0.0**
+**2020-03-31 3.0.0**
 
-* Use the maintained gem kt-paperclip instead of the deprecated papercip.
+* Use the maintained gem kt-paperclip instead of the deprecated papercip gem.
 
 **2015-01-16 2.0.0**
 


### PR DESCRIPTION
This makes the builds work on Travis. See [this documentation](https://docs.travis-ci.com/user/languages/ruby/#bundler-20)

I looked into publishing the gem via Travis but ran into lots of complications. So I plan to
- publish gem manually
- add extra owners to the gem so others in the company can manually publish it themselves.

So in this review, I am asking if this plan sounds OK, and for an OK for all the changes I have made to the gem since forking it.